### PR TITLE
Manually bootstrap app only if modules is systemjs

### DIFF
--- a/generators/app/templates/src/index.html
+++ b/generators/app/templates/src/index.html
@@ -6,8 +6,12 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width">
   </head>
-
+  
+<% if (modules === 'webpack') { -%>
+  <body ng-app="app">
+<% } else { -%>
   <body>
+<% } -%>
     <app>Loading...</app>
   </body>
 </html>

--- a/generators/hello/modules/templates/src/index.babel
+++ b/generators/hello/modules/templates/src/index.babel
@@ -11,5 +11,7 @@ export const app = 'app';
 angular
   .module(app, [])
   .component('app', hello);
+<% if (modules === 'systemjs') { -%>
 
 angular.bootstrap(document, ['app']);
+<% } -%>

--- a/generators/hello/modules/templates/src/index.js
+++ b/generators/hello/modules/templates/src/index.js
@@ -12,5 +12,7 @@ module.exports = app;
 angular
   .module(app, [])
   .component('app', hello);
+<% if (modules === 'systemjs') { -%>
 
 angular.bootstrap(document, ['app']);
+<% } -%>

--- a/generators/hello/modules/templates/src/index.ts
+++ b/generators/hello/modules/templates/src/index.ts
@@ -13,5 +13,7 @@ export const app: string = 'app';
 angular
   .module(app, [])
   .component('app', hello);
+<% if (modules === 'systemjs') { -%>
 
 angular.bootstrap(document, ['app']);
+<% } -%>

--- a/generators/techs/modules/templates/src/index.babel
+++ b/generators/techs/modules/templates/src/index.babel
@@ -15,5 +15,7 @@ angular
   .component('fountainHeader', header)
   .component('fountainTitle', title)
   .component('fountainFooter', footer);
+<% if (modules === 'systemjs') { -%>
 
 angular.bootstrap(document, ['app']);
+<% } -%>

--- a/generators/techs/modules/templates/src/index.js
+++ b/generators/techs/modules/templates/src/index.js
@@ -15,5 +15,7 @@ angular
   .component('fountainHeader', header)
   .component('fountainTitle', title)
   .component('fountainFooter', footer);
+<% if (modules === 'systemjs') { -%>
 
 angular.bootstrap(document, ['app']);
+<% } -%>

--- a/generators/techs/modules/templates/src/index.ts
+++ b/generators/techs/modules/templates/src/index.ts
@@ -17,5 +17,7 @@ angular
   .component('fountainHeader', header)
   .component('fountainTitle', title)
   .component('fountainFooter', footer);
+<% if (modules === 'systemjs') { -%>
 
 angular.bootstrap(document, ['app']);
+<% } -%>


### PR DESCRIPTION
Use `angular.bootstrap` instead of `ng-app` only for `SytemJS`, fixes https://github.com/FountainJS/generator-fountain-webapp/issues/18
