### PR TITLE
Fix missing prefix for angular1/inject/todoMVC which throws warnings

### DIFF
--- a/generators/todoMVC/inject/templates/src/app/components/Footer.spec.ts
+++ b/generators/todoMVC/inject/templates/src/app/components/Footer.spec.ts
@@ -1,7 +1,7 @@
 /// <reference path="../../../typings/index.d.ts" />
 
 describe('Footer component', () => {
-  beforeEach(module('app', $provide => {
+  beforeEach(angular.mock.module('app', $provide => {
     $provide.factory('footerComponent', () => {
       return {
         templateUrl: 'app/components/Footer.html'

--- a/generators/todoMVC/inject/templates/src/app/components/Header.spec.ts
+++ b/generators/todoMVC/inject/templates/src/app/components/Header.spec.ts
@@ -21,13 +21,13 @@ describe('Header component', () => {
     }
   }
 
-  beforeEach(module('app', $provide => {
+  beforeEach(angular.mock.module('app', $provide => {
     $provide.factory('todoService', () => {
       return new MockTodoService();
     });
   }));
 
-  beforeEach(module('app', $provide => {
+  beforeEach(angular.mock.module('app', $provide => {
     $provide.factory('headerComponent', () => {
       return {
         templateUrl: 'app/components/Header.html'

--- a/generators/todoMVC/inject/templates/src/app/components/MainSection.spec.ts
+++ b/generators/todoMVC/inject/templates/src/app/components/MainSection.spec.ts
@@ -12,7 +12,7 @@ describe('MainSection component', () => {
 
   let component;
 
-  beforeEach(module('app', $provide => {
+  beforeEach(angular.mock.module('app', $provide => {
     $provide.factory('mainSection', () => {
       return {
         templateUrl: 'app/components/MainSection.html'
@@ -20,7 +20,7 @@ describe('MainSection component', () => {
     });
   }));
 
-  beforeEach(module('app', $provide => {
+  beforeEach(angular.mock.module('app', $provide => {
     $provide.factory('todoService', () => {
       return new MockTodoService();
     });

--- a/generators/todoMVC/inject/templates/src/app/components/TodoItem.spec.ts
+++ b/generators/todoMVC/inject/templates/src/app/components/TodoItem.spec.ts
@@ -1,7 +1,7 @@
 /// <reference path="../../../typings/index.d.ts" />
 
 describe('TodoItem component', () => {
-  beforeEach(module('app', $provide => {
+  beforeEach(angular.mock.module('app', $provide => {
     $provide.factory('todoItem', () => {
       return {
         templateUrl: 'app/components/TodoItem.html'

--- a/generators/todoMVC/inject/templates/src/app/components/TodoTextInput.spec.ts
+++ b/generators/todoMVC/inject/templates/src/app/components/TodoTextInput.spec.ts
@@ -4,7 +4,7 @@ describe('TodoTextInput component', () => {
   class MockTodoService {
   }
 
-  beforeEach(module('app', $provide => {
+  beforeEach(angular.mock.module('app', $provide => {
     $provide.factory('todoTextInput', () => {
       return {
         templateUrl: 'app/components/TodoTextInput.html'


### PR DESCRIPTION
Fixes https://github.com/FountainJS/generator-fountain-webapp/issues/80