### PR TITLE
Fix html viewport settings

### DIFF
--- a/generators/app/templates/src/index.html
+++ b/generators/app/templates/src/index.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8">
     <title>FountainJS</title>
     <meta name="description" content="">
-    <meta name="viewport" content="width=device-width">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" type="image/png" href="http://fountainjs.io/assets/imgs/fountain.png" />
   </head>
 


### PR DESCRIPTION
`initial-scale` should be set to `1.0` to set the initial zoom level.

See http://www.w3schools.com/css/css_rwd_viewport.asp

Fixes an issue on mobile where right sidenavs from angular-material cause the page to distort while opening and closing.